### PR TITLE
Fix socket_inet_p.py

### DIFF
--- a/extproxy/socket_inet_p.py
+++ b/extproxy/socket_inet_p.py
@@ -58,7 +58,7 @@ def inet_ntop(family, ip_packed):
 
 def _explode_ip_string(ip_string):
     if ip_string[:1] == "[":
-        ip_string = [1:-1]
+        ip_string = ip_string[1:-1]
     assert 1 < len(ip_string) < 40
     if ip_string[:1] == ":":
         assert ip_string[:2] == "::"


### PR DESCRIPTION
I've noticed that the code fails to compile with py3compile due to a syntax error, as the name of the array ip_string is missing